### PR TITLE
Set the ESP to no power saving more

### DIFF
--- a/ESP/lib/src/network/WifiHandler/wifiHandler.cpp
+++ b/ESP/lib/src/network/WifiHandler/wifiHandler.cpp
@@ -4,6 +4,8 @@ void WiFiHandler::setupWifi(const char *ssid, const char *password, StateManager
 {
   log_d("Initializing connection to wifi");
 
+  WiFi.mode(WIFI_STA);
+  WiFi.setSleep(WIFI_PS_NONE);
   WiFi.begin(ssid, password);
 
   log_d("connecting");


### PR DESCRIPTION
Fixes the random issue with stream freezing for a couple of frames, or outright completely. 

Thanks to Lilly Nightfury:  https://www.reddit.com/r/esp32/comments/np9p50/esp32_cam_short_freezes/