### PR TITLE
ignore device monitor logs

### DIFF
--- a/ESP/.gitignore
+++ b/ESP/.gitignore
@@ -1,3 +1,4 @@
+platformio-device-monitor-*-*.log
 .pio
 .vscode
 build


### PR DESCRIPTION
updated the gitignore to ignore all logs generated by using the serial device monitor in platformio