### PR TITLE
Add tasks for scheduling the restart of the esp

### DIFF
--- a/ESP/lib/src/data/config/project_config.cpp
+++ b/ESP/lib/src/data/config/project_config.cpp
@@ -72,7 +72,7 @@ void ProjectConfig::save()
     wifiConfigSave();
     wifiTxPowerConfigSave();
     end(); // we call end() here to close the connection to the NVS partition, we only do this because we call ESP.restart() next.
-    ESP.restart();
+    OpenIrisTasks::ScheduleRestart(2000);
 }
 
 void ProjectConfig::wifiConfigSave()

--- a/ESP/lib/src/data/config/project_config.hpp
+++ b/ESP/lib/src/data/config/project_config.hpp
@@ -6,14 +6,17 @@
 #include <vector>
 #include <string>
 
+#include "tasks/tasks.hpp"
 #include "data/utilities/Observer.hpp"
 #include "data/utilities/helpers.hpp"
 
 class ProjectConfig : public Preferences, public ISubject
 {
 public:
-	ProjectConfig(const std::string &name = std::string(),
-				  const std::string &mdnsName = std::string());
+	ProjectConfig(
+		const std::string &name = std::string(),
+		const std::string &mdnsName = std::string()
+	);
 	virtual ~ProjectConfig();
 	void load();
 	void save();

--- a/ESP/lib/src/network/api/baseAPI/baseAPI.cpp
+++ b/ESP/lib/src/network/api/baseAPI/baseAPI.cpp
@@ -266,7 +266,7 @@ void BaseAPI::rebootDevice(AsyncWebServerRequest *request)
 	case GET:
 	{
 		request->send(200, MIMETYPE_JSON, "{\"msg\":\"Rebooting Device\"}");
-		ESP.restart();
+		OpenIrisTasks::ScheduleRestart(2000);
 	}
 	default:
 	{

--- a/ESP/lib/src/network/api/baseAPI/baseAPI.hpp
+++ b/ESP/lib/src/network/api/baseAPI/baseAPI.hpp
@@ -22,6 +22,7 @@
 #include <AsyncTCP.h>
 
 #include "data/utilities/network_utilities.hpp"
+#include "tasks/tasks.hpp"
 
 #include "data/config/project_config.hpp"
 #include "data/StateManager/StateManager.hpp"

--- a/ESP/lib/src/tasks/tasks.cpp
+++ b/ESP/lib/src/tasks/tasks.cpp
@@ -1,0 +1,9 @@
+#include "tasks.hpp"
+
+void OpenIrisTasks::ScheduleRestart(int milliseconds) {
+    int initialTime = millis(); 
+    while (millis() - initialTime <= milliseconds) {
+        continue;
+    }
+    ESP.restart();
+}

--- a/ESP/lib/src/tasks/tasks.hpp
+++ b/ESP/lib/src/tasks/tasks.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#ifndef TASKS_HPP
+#define TASKS_HPP
+
+#include <Arduino.h>
+
+namespace OpenIrisTasks {
+void ScheduleRestart(int milliseconds);
+}
+
+#endif // TASKS_HPP

--- a/ESP/src/main.cpp
+++ b/ESP/src/main.cpp
@@ -17,7 +17,6 @@
 
 int STREAM_SERVER_PORT = 80;
 int CONTROL_SERVER_PORT = 81;
-
 /**
  * @brief ProjectConfig object
  * @brief This is the main configuration object for the project
@@ -25,6 +24,7 @@ int CONTROL_SERVER_PORT = 81;
  * @param mdnsName The mDNS hostname to use
  */
 ProjectConfig deviceConfig("openiris", MDNS_HOSTNAME);
+
 #if ENABLE_OTA
 OTA ota(&deviceConfig);
 #endif // ENABLE_OTA


### PR DESCRIPTION
Adds a simple tasks mechanism making it so the API has some time to send a response before the restart happens