### PR TITLE
Increase XCLK frequency to 24MHz for higher frame rates on ESP32-S3 boards

### DIFF
--- a/ESP/lib/src/io/camera/cameraHandler.cpp
+++ b/ESP/lib/src/io/camera/cameraHandler.cpp
@@ -11,10 +11,12 @@ void CameraHandler::setupCameraPinout() {
   log_i("Camera module is undefined");
 #endif
 
-  int xclk_freq_hz = 16500000;  // 10000000 stable,
-                                // 16500000 optimal,
-                                // 20000000 max freq on ESP32-CAM
-                                // 24000000 max freq on OV2640 sensor
+  // camera external clock signal frequencies
+  // 10000000 stable
+  // 16500000 optimal freq on ESP32-CAM (default)
+  // 20000000 max freq on ESP32-CAM
+  // 24000000 optimal freq on ESP32-S3
+  int xclk_freq_hz = 16500000;
 
 #if CONFIG_CAMERA_MODULE_ESP_EYE
   /* IO13, IO14 is designed for JTAG by default,
@@ -56,9 +58,7 @@ void CameraHandler::setupCameraPinout() {
   config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
-  config.xclk_freq_hz = xclk_freq_hz;  // 10000000 stable,
-                                       // 16500000 optimal,
-                                       // 20000000 max fps
+  config.xclk_freq_hz = xclk_freq_hz;
 }
 
 void CameraHandler::setupBasicResolution() {

--- a/ESP/lib/src/io/camera/cameraHandler.cpp
+++ b/ESP/lib/src/io/camera/cameraHandler.cpp
@@ -11,6 +11,11 @@ void CameraHandler::setupCameraPinout() {
   log_i("Camera module is undefined");
 #endif
 
+  int xclk_freq_hz = 16500000;  // 10000000 stable,
+                                // 16500000 optimal,
+                                // 20000000 max freq on ESP32-CAM
+                                // 24000000 max freq on OV2640 sensor
+
 #if CONFIG_CAMERA_MODULE_ESP_EYE
   /* IO13, IO14 is designed for JTAG by default,
    * to use it as generalized input,
@@ -27,6 +32,9 @@ void CameraHandler::setupCameraPinout() {
   pinMode(13, INPUT_PULLUP);
   pinMode(14, INPUT_PULLUP);
   log_i("CAM_BOARD");
+#elif CONFIG_CAMERA_MODULE_ESPS3WROVER
+  /* ESP32-S3 is capable of using higher freqs */
+  xclk_freq_hz = 24000000;
 #endif
 
   config.ledc_channel = LEDC_CHANNEL_0;
@@ -48,9 +56,9 @@ void CameraHandler::setupCameraPinout() {
   config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
-  config.xclk_freq_hz = 16500000;  // 10000000 stable,
-                                   // 16500000 optimal,
-                                   // 20000000 max fps
+  config.xclk_freq_hz = xclk_freq_hz;  // 10000000 stable,
+                                       // 16500000 optimal,
+                                       // 20000000 max fps
 }
 
 void CameraHandler::setupBasicResolution() {


### PR DESCRIPTION
Hi there,

I have increased the _XCLK frequency_ for the OV2640 camera sensor to 24MHz, with the goal of achieving higher frame rates when used with _ESP32-S3_ boards.

This change has been tested using three _ESP32-S3 Freenove_ boards and has successfully increased the frame rate to around 65-70 frames per second over serial.

**Note:**
The updated configuration operates within the specified input clock frequency range (10 MHz to 48 MHz) for the OV2640 sensor.

Please verify on your hardware and provide feedback or merge the changes if everything looks good.